### PR TITLE
Includes last invoice date for cabinet

### DIFF
--- a/StreetLighting/StreetlightControlCabinet/doc/spec.md
+++ b/StreetLighting/StreetlightControlCabinet/doc/spec.md
@@ -76,7 +76,7 @@ responsible, district, neighbourhood, etc.
     + Attribute Type: [Date](http://schema.org/DateTime)
     + Optional
 
-+ `dateLastInvoice` : Date at which the last invoice for the cabinet was issued.
++ `dateLastInvoice` : Date at which the last invoice corresponding to the energy consumed by the circuits controlled by this cabinet.
     + Attribute Type: [Date](http://schema.org/DateTime)
     + Optional
 

--- a/StreetLighting/StreetlightControlCabinet/doc/spec.md
+++ b/StreetLighting/StreetlightControlCabinet/doc/spec.md
@@ -75,7 +75,11 @@ responsible, district, neighbourhood, etc.
 + `dateLastProgramming` : Date at which there was a programming operation over the cabinet.
     + Attribute Type: [Date](http://schema.org/DateTime)
     + Optional
-    
+
++ `dateLastInvoice` : Date at which the last invoice for the cabinet was issued.
+    + Attribute Type: [Date](http://schema.org/DateTime)
+    + Optional
+
 + `nextActuationDeadline` : Deadline for next actuation to be performed (programming, testing, etc.).
     + Attribute Type: [DateTime](http://schema.org/DateTime)
     + Optional   


### PR DESCRIPTION
Hi, team,

We're proposing this attribute to handle invoices-oriented grouping for energy counters.

Since invoices issuing date may differ over time, tracking dates for invoices seems a good solution.

Regards
