### PR TITLE
FIX location fields along all models

### DIFF
--- a/Alert/doc/spec.md
+++ b/Alert/doc/spec.md
@@ -50,7 +50,7 @@ found [here](../schema.json).
     + Optional
 
 + `location` : Location of alert represented by a GeoJSON geometry.
-    + Attribute type: `geo:json`.
+    + Attribute type: any of the location formats supported by NGSIv2 (`geo:point`, `geo:line`, `geo:box`, `geo:polygon` or `geo:json`).
     + Normative References: [rfc7946](https://tools.ietf.org/html/rfc7946)
     + Mandatory if `address` is not present
 

--- a/Device/Device/doc/spec.md
+++ b/Device/Device/doc/spec.md
@@ -58,7 +58,7 @@ and which are not currently covered by the standard attributes defined by this m
     + Optional
     
 + `location` : Location of this device represented by a GeoJSON geometry of type point. 
-    + Attribute type: `geo:json`.
+    + Attribute type: `geo:point` or `geo:json` (of type `Point`).
     + Normative References: [https://tools.ietf.org/html/rfc7946](https://tools.ietf.org/html/rfc7946)
     + Optional.
     

--- a/Environment/AeroAllergenObserved/doc/spec.md
+++ b/Environment/AeroAllergenObserved/doc/spec.md
@@ -30,7 +30,7 @@ A JSON Schema corresponding to this data model can be found [here](http://fiware
     + Read-Only. Automatically generated.
 
 + `location` : Location of the aero allergens observation represented by a GeoJSON geometry. 
-    + Attribute type: `geo:json`.
+    + Attribute type: any of the location formats supported by NGSIv2 (`geo:point`, `geo:line`, `geo:box`, `geo:polygon` or `geo:json`).
     + Normative References: [https://tools.ietf.org/html/rfc7946](https://tools.ietf.org/html/rfc7946)
     + Mandatory if `address` is not defined. 
     

--- a/Environment/AirQualityObserved/doc/spec.md
+++ b/Environment/AirQualityObserved/doc/spec.md
@@ -22,7 +22,7 @@ A JSON Schema corresponding to this data model can be found [here](http://fiware
     + Read-Only. Automatically generated.
 
 + `location` : Location of the air quality observation represented by a GeoJSON geometry. 
-    + Attribute type: `geo:json`.
+    + Attribute type: any of the location formats supported by NGSIv2 (`geo:point`, `geo:line`, `geo:box`, `geo:polygon` or `geo:json`).
     + Normative References: [https://tools.ietf.org/html/rfc7946](https://tools.ietf.org/html/rfc7946)
     + Mandatory if `address` is not defined. 
     

--- a/Environment/NoiseLevelObserved/doc/spec.md
+++ b/Environment/NoiseLevelObserved/doc/spec.md
@@ -20,7 +20,7 @@ This entity is primarily associated with the Smart City and environment vertical
     + Read-Only. Automatically generated.
 
 + `location` : Location of this observation represented by a GeoJSON geometry. 
-    + Attribute type: `geo:json`.
+    + Attribute type: any of the location formats supported by NGSIv2 (`geo:point`, `geo:line`, `geo:box`, `geo:polygon` or `geo:json`).
     + Normative References: [https://tools.ietf.org/html/rfc7946](https://tools.ietf.org/html/rfc7946)
     + Mandatory if `address` is not present.
 

--- a/Environment/WaterQualityObserved/doc/spec.md
+++ b/Environment/WaterQualityObserved/doc/spec.md
@@ -21,7 +21,7 @@ A JSON Schema corresponding to this data model can be found [here](http://fiware
     + Read-Only. Automatically generated.
 
 + `location` : Location where measurements have been taken, represented by a GeoJSON Point. 
-    + Attribute type: `geo:json`.
+    + Attribute type: `geo:point` or `geo:json` (of type `Point`).
     + Normative References: [https://tools.ietf.org/html/draft-ietf-geojson-03](https://tools.ietf.org/html/draft-ietf-geojson-03)
     + Mandatory if `address` is not present.
     

--- a/Parking/OffStreetParking/doc/spec.md
+++ b/Parking/OffStreetParking/doc/spec.md
@@ -26,7 +26,7 @@ DATEX II terms can be found at [http://datexbrowser.tamtamresearch.com/](http://
     + Read-Only. Automatically generated.
     
 + `location` : Geolocation of the parking site represented by a GeoJSON (Multi)Polygon or Point.
-    + Attribute type: `geo:json`.
+    + Attribute type: `geo:point`, `geo:box`, `geo:polygon` or `geo:json` (of type `Point`, `Polygon` or `MultiPolygon`).
     + Normative References: [https://tools.ietf.org/html/rfc7946](https://tools.ietf.org/html/rfc7946)
     + Mandatory if `address` is not defined.
     

--- a/Parking/OnStreetParking/doc/spec.md
+++ b/Parking/OnStreetParking/doc/spec.md
@@ -35,7 +35,7 @@ DATEX II terms can be found at [http://datexbrowser.tamtamresearch.com/](http://
     + Mandatory
           
 + `location` : Geolocation of the parking site represented by a GeoJSON (Multi)Polygon.
-    + Attribute type: `geo:json`.
+    + Attribute type: `geo:box`, `geo:polygon` or `geo:json` (of type `Polygon` or `MultiPolygon`).
     + Normative References: [https://tools.ietf.org/html/rfc7946](https://tools.ietf.org/html/rfc7946)
     + Mandatory if `address`is not defined. 
     

--- a/Parking/ParkingAccess/doc/spec.md
+++ b/Parking/ParkingAccess/doc/spec.md
@@ -11,7 +11,7 @@ Represents an access point to a parking site, normally an offstreet parking.
 + `type` : Entity type. It must be equal to `ParkingAccess`.
 
 + `location` : Geolocation of the access point represented by a GeoJSON Point.
-    + Attribute type: `geo:json`.
+    + Attribute type: `geo:point` or `geo:json` (of type `Point`).
     + Normative References: [https://tools.ietf.org/html/rfc7946](https://tools.ietf.org/html/rfc7946)
     + Mandatory
     

--- a/Parking/ParkingGroup/doc/spec.md
+++ b/Parking/ParkingGroup/doc/spec.md
@@ -43,7 +43,7 @@ per group type.
     + Mandatory
        
 + `location` : Geolocation of the parking group represented by a GeoJSON (Multi)Polygon or Point.
-    + Attribute type: `geo:json`.
+    + Attribute type: `geo:point`, `geo:box`, `geo:polygon` or `geo:json` (of type `Point`, `Polygon` or `MultiPolygon`).
     + Normative References: [https://tools.ietf.org/html/rfc7946](https://tools.ietf.org/html/rfc7946)
     + Optional
 

--- a/Parking/ParkingSpot/doc/spec.md
+++ b/Parking/ParkingSpot/doc/spec.md
@@ -30,7 +30,7 @@ Thus, an entity of type `ParkingSpot` cannot exist without a containing entity o
     + Optional
 
 + `location` : Geolocation of the parking spot, represented by a GeoJSON Point.
-    + Attribute type: `geo:json`.
+    + Attribute type: `geo:point` or `geo:json` (of type `Point`).
     + Normative References: [https://tools.ietf.org/html/rfc7946](https://tools.ietf.org/html/rfc7946)
     + Mandatory. Not nullable (if `address` is not defined).  
 

--- a/ParksAndGardens/FlowerBed/doc/spec.md
+++ b/ParksAndGardens/FlowerBed/doc/spec.md
@@ -55,7 +55,7 @@ to which the trees, or plants in the flower bed belong.
     + Optional
 
 + `location` : Location of the flower bed represented by a GeoJSON geometry. 
-    + Attribute type: `geo:json`.
+    + Attribute type: any of the location formats supported by NGSIv2 (`geo:point`, `geo:line`, `geo:box`, `geo:polygon` or `geo:json`).
     + Normative References: [https://tools.ietf.org/html/rfc7946](https://tools.ietf.org/html/rfc7946)
     + Mandatory if `address` is not defined
     

--- a/ParksAndGardens/Garden/doc/spec.md
+++ b/ParksAndGardens/Garden/doc/spec.md
@@ -26,7 +26,7 @@ A JSON Schema corresponding to this data model can be found {{add link to JSON S
     + Optional
 
 + `location` : Location of this garden represented by a GeoJSON geometry. 
-    + Attribute type: `geo:json`.
+    + Attribute type: any of the location formats supported by NGSIv2 (`geo:point`, `geo:line`, `geo:box`, `geo:polygon` or `geo:json`).
     + Normative References: [https://tools.ietf.org/html/rfc7946](https://tools.ietf.org/html/rfc7946)
     + Mandatory if `address` is not defined. 
     

--- a/ParksAndGardens/GreenspaceRecord/doc/spec.md
+++ b/ParksAndGardens/GreenspaceRecord/doc/spec.md
@@ -26,7 +26,7 @@ A JSON Schema corresponding to this data model can be found {{add link to JSON S
     + Optional
 
 + `location` : Location of the area concerned by this record and represented by a GeoJSON geometry. 
-    + Attribute type: `geo:json`.
+    + Attribute type: any of the location formats supported by NGSIv2 (`geo:point`, `geo:line`, `geo:box`, `geo:polygon` or `geo:json`).
     + Normative References: [https://tools.ietf.org/html/rfc7946](https://tools.ietf.org/html/rfc7946)
     + Mandatory
     

--- a/PointOfInteraction/SmartPointOfInteraction/doc/spec.md
+++ b/PointOfInteraction/SmartPointOfInteraction/doc/spec.md
@@ -18,8 +18,8 @@ The data model includes information regarding the area/surface covered by the te
     + Allowed values: `information`, `entertainment`, `infotainment`, `co-creation` or any other extended value defined by the application.
     + Mandatory
     
-+ `areaCovered` : Defines the area covered by the Smart Point of Interaction using geoJSON format. It can be represented by a feature of type `Polygon` or `Multipolygon`.
-    + Attribute type: `geo:json`.
++ `areaCovered` : Defines the area covered by the Smart Point of Interaction using GepJSON format. It can be represented by a feature of type `Polygon` or `Multipolygon`.
+    + Attribute type: `geo:box`, `geo:polygon` or `geo:json` (of type `Polygon` or `MultiPolygon`).
     + Normative References: [https://tools.ietf.org/html/rfc7946](https://tools.ietf.org/html/rfc7946)
     + Optional    
     

--- a/PointOfInterest/Beach/doc/spec.md
+++ b/PointOfInterest/Beach/doc/spec.md
@@ -41,7 +41,7 @@ any property specified by schema.org and which domain is `https://schema.org/Bea
     + Optional
 
 + `location` : Location of this beach represented by a GeoJSON geometry, usually a `Point` or a Polygon. 
-    + Attribute type: `geo:json`.
+    + Attribute type: any of the location formats supported by NGSIv2 (`geo:point`, `geo:line`, `geo:box`, `geo:polygon` or `geo:json`).
     + Normative References: [https://tools.ietf.org/html/rfc7946](https://tools.ietf.org/html/rfc7946)
     + Mandatory if `address` is not defined. 
     

--- a/PointOfInterest/Museum/doc/spec.md
+++ b/PointOfInterest/Museum/doc/spec.md
@@ -41,7 +41,7 @@ any property specified by schema.org and which domain is `https://schema.org/Mus
     + Optional
 
 + `location` : Location of this museum represented by a GeoJSON geometry, usually a `Point` or a `Polygon`. 
-    + Attribute type: `geo:json`.
+    + Attribute type: any of the location formats supported by NGSIv2 (`geo:point`, `geo:line`, `geo:box`, `geo:polygon` or `geo:json`).
     + Normative References: [https://tools.ietf.org/html/rfc7946](https://tools.ietf.org/html/rfc7946)
     + Mandatory if `address` is not defined. 
     

--- a/PointOfInterest/PointOfInterest/doc/spec.md
+++ b/PointOfInterest/PointOfInterest/doc/spec.md
@@ -40,7 +40,7 @@ A JSON Schema corresponding to this data model can be found [here](http://fiware
     + Optional
 
 + `location` : Location of the point of interest represented by a GeoJSON geometry, usually a `Point`. 
-    + Attribute type: `geo:json`.
+    + Attribute type: any of the location formats supported by NGSIv2 (`geo:point`, `geo:line`, `geo:box`, `geo:polygon` or `geo:json`).
     + Normative References: [https://tools.ietf.org/html/rfc7946](https://tools.ietf.org/html/rfc7946)
     + Mandatory if `address` is not defined. 
     

--- a/StreetLighting/Streetlight/doc/spec.md
+++ b/StreetLighting/Streetlight/doc/spec.md
@@ -13,7 +13,7 @@ Such data is captured by entities of type `StreetlightModel`.
 + `type` : It must be equal to `Streetlight`.
 
 + `location` : Streetlight's location represented by a GeoJSON Point. 
-    + Attribute type: `geo:json`.
+    + Attribute type: `geo:point` or `geo:json` (of type `Point`).
     + Normative References: [https://tools.ietf.org/html/draft-ietf-geojson-03](https://tools.ietf.org/html/draft-ietf-geojson-03)
     + Mandatory if `address` is not present.
     

--- a/StreetLighting/StreetlightControlCabinet/doc/spec.md
+++ b/StreetLighting/StreetlightControlCabinet/doc/spec.md
@@ -9,7 +9,7 @@ It represents equipment, usually on street, used to the automated control of a g
 + `type` : It must be equal to `StreetlightControlCabinet`.
 
 + `location` : Control cabinet's location represented by a GeoJSON point. 
-    + Attribute type: `geo:json`.
+    + Attribute type: `geo:point` or `geo:json` (of type `Point`).
     + Normative References: [https://tools.ietf.org/html/draft-ietf-geojson-03](https://tools.ietf.org/html/draft-ietf-geojson-03)
     + Mandatory
 

--- a/StreetLighting/StreetlightGroup/doc/spec.md
+++ b/StreetLighting/StreetlightGroup/doc/spec.md
@@ -10,7 +10,7 @@ together by the same automated system (cabinet controller).
 + `type` : It must be equal to `StreetlightGroup`.
 
 + `location` : Streetlight's group location represented by a GeoJSON (multi)geometry. 
-    + Attribute type: `geo:json`.
+    + Attribute type: any of the location formats supported by NGSIv2 (`geo:point`, `geo:line`, `geo:box`, `geo:polygon` or `geo:json`).
     + Normative References: [https://tools.ietf.org/html/draft-ietf-geojson-03](https://tools.ietf.org/html/draft-ietf-geojson-03)
     + Mandatory
         

--- a/Transportation/Bike/BikeHireDockingStation/doc/spec.md
+++ b/Transportation/Bike/BikeHireDockingStation/doc/spec.md
@@ -28,9 +28,8 @@ A JSON Schema corresponding to this data model can be found [here](https://fiwar
         ](http://schema.org/DateTime)
     +   Read-Only. Automatically generated.
 
-+   `location` : Geolocation of the station represented by a GeoJSON
-    (Multi)Polygon or Point.
-    +   Attribute type: `geo:json`.
++   `location` : Geolocation of the station represented by a GeoJSON (Multi)Polygon or Point.
+    +   Attribute type: `geo:point`, `geo:box`, `geo:polygon` or `geo:json` (of type `Point`, `Polygon` or `MultiPolygon`).
     +   Normative References: [https://tools.ietf.org/html/rfc7946](https://tools.ietf.org/html/rfc7946)
     +   Mandatory if `address` is not defined.
 

--- a/Transportation/RoadSegment/doc/spec.md
+++ b/Transportation/RoadSegment/doc/spec.md
@@ -49,17 +49,17 @@ This data model has been developed in cooperation with mobile operators and the 
     + Mandatory
     
 + `location` : A GeoJSON (multi)line string which defines this road segment.
-    + Attribute type: `geo:json`.
+    + Attribute type: `geo:json` (of type `LineString` or `MultiLineString`).
     + Normative References: [https://tools.ietf.org/html/rfc7946](https://tools.ietf.org/html/rfc7946)
     + Mandatory
     
 + `startPoint` : The start point of this road segment encoded as a GeoJSON point. 
-    + Attribute type: `geo:json`
+    + Attribute type: `geo:point` or `geo:json` (of type `Point`).
     + Normative References: [https://tools.ietf.org/html/rfc7946](https://tools.ietf.org/html/rfc7946)
     + Mandatory
 
 + `endPoint` : The end point of this road segment encoded as a GeoJSON point.
-    + Attribute type: `geo:json`
+    + Attribute type: `geo:point` or `geo:json` (of type `Point`).
     + Normative References: [https://tools.ietf.org/html/rfc7946](https://tools.ietf.org/html/rfc7946)
     + Mandatory
     

--- a/Transportation/TrafficFlowObserved/doc/spec.md
+++ b/Transportation/TrafficFlowObserved/doc/spec.md
@@ -12,7 +12,7 @@ the Automotive and Smart City vertical segments and related IoT applications.
 + `type` : Entity type. It must be equal to `TrafficFlowObserved`.
 
 + `location` : Location of this traffic flow observation represented by a GeoJSON geometry. 
-    + Attribute type: `geo:json`.
+    + Attribute type: any of the location formats supported by NGSIv2 (`geo:point`, `geo:line`, `geo:box`, `geo:polygon` or `geo:json`).
     + Normative References: [https://tools.ietf.org/html/rfc7946](https://tools.ietf.org/html/rfc7946)
     + Mandatory if `refRoadSegment` is not present.
 

--- a/Transportation/Vehicle/Vehicle/doc/spec.md
+++ b/Transportation/Vehicle/Vehicle/doc/spec.md
@@ -41,7 +41,7 @@ This is different than the vehicle type (car, lorry, etc.) represented by the `v
 
 + `location` : Vehicle's last known location represented by a GeoJSON Point. Such point may contain the vehicle's
 *altitude* as the third component of the `coordinates` array. 
-    + Attribute type: `geo:json`.
+    + Attribute type: `geo:point` or `geo:json` (of type `Point`).
     + Normative References: [https://tools.ietf.org/html/rfc7946](https://tools.ietf.org/html/rfc7946)
     + Attribute metadata:
         + `timestamp`: Timestamp which captures when the vehicle was at that location.
@@ -52,7 +52,7 @@ This is different than the vehicle type (car, lorry, etc.) represented by the `v
     
 + `previousLocation` : Vehicle's previous location represented by a GeoJSON Point. Such point may contain the previous vehicle's
 *altitude* as the third component of the`coordinates` array.
-    + Attribute type: `geo:json`.
+    + Attribute type: `geo:point` or `geo:json` (of type `Point`).
     + Normative References: [https://tools.ietf.org/html/rfc7946](https://tools.ietf.org/html/rfc7946)
     + Attribute metadata:
         + `timestamp`: Timestamp which captures when the vehicle was at that location.

--- a/UrbanMobility/Stop/doc/spec.md
+++ b/UrbanMobility/Stop/doc/spec.md
@@ -38,8 +38,8 @@ It represents a GTFS `stop` which `location_type` shall be equal to `0`.
   + Attribute type: Property. [Text](https://schema.org/Text)
   + Optional
  
-+ `location`: Stop's location encoded as GeoJSON Point which coordinates shall be in the form [`stop_long`,`stop_lat`].
-  + Attribute type: GeoProperty. `geo:json`.
++ `location`: Stop's location encoded as GeoJSON Point.
+  + Attribute type: `geo:point` or `geo:json` (of type `Point`).
   + Normative References: [rfc7946](https://tools.ietf.org/html/rfc7946)
   + Mandatory
 

--- a/UrbanMobility/Trip/doc/spec.md
+++ b/UrbanMobility/Trip/doc/spec.md
@@ -41,9 +41,9 @@ See [https://developers.google.com/transit/gtfs/reference/#tripstxt](https://dev
   + Attribute type: Relationship. It shall point to an Entity of Type [gtfs:Service](../../doc/Service/spec.md) 
   + Optional
   
-+ `location`: The geographical shape associated to the trip encoded as GeoJSON `LineString` or `MultiLineString`.
++ `location`: The geographical shape associated to the trip encoded as GeoJSON.
 The coordinates shall be obtained from the `shapes.txt` feed file as per the value of `shape_id`. 
-  + Attribute type: GeoProperty. `geo:json`
+  + Attribute type: `geo:json` (of type `LineString` or `MultiLineString`).
   + Optional
      
 + `hasRoute`: Same as `route_id`.

--- a/User/UserContext/doc/spec.md
+++ b/User/UserContext/doc/spec.md
@@ -28,7 +28,7 @@ A JSON Schema corresponding to this data model can be found [here](../schema.jso
     + Mandatory
 
 + `location` : Current location of the User represented by a GeoJSON geometry.
-    + Attribute type: `geo:json`.
+    + Attribute type: any of the location formats supported by NGSIv2 (`geo:point`, `geo:line`, `geo:box`, `geo:polygon` or `geo:json`).
     + Normative References: [https://tools.ietf.org/html/rfc7946](https://tools.ietf.org/html/rfc7946)
     + Mandatory if `address` is not defined.
 

--- a/WasteManagement/WasteContainer/doc/spec.md
+++ b/WasteManagement/WasteContainer/doc/spec.md
@@ -13,7 +13,7 @@ A JSON Schema corresponding to this data model can be found [here](http://fiware
 + `type` : Entity type. It must be equal to `WasteContainer`.
 
 + `location` : Container's location represented by a GeoJSON Point.
-    + Attribute type: `geo:json`.
+    + Attribute type: `geo:point` or `geo:json` (of type `Point`).
     + Normative References: [https://tools.ietf.org/html/rfc7946](https://tools.ietf.org/html/rfc7946)
     + Mandatory if `address` is not present.
 

--- a/WasteManagement/WasteContainerIsle/doc/spec.md
+++ b/WasteManagement/WasteContainerIsle/doc/spec.md
@@ -11,7 +11,7 @@ A geographical area which keeps one or more waste containers.
 + `type` : Entity type. It must be equal to `WasteContainerIsle`. 
 
 + `location` : Location of the isle represented by a GeoJSON Polygon.
-    + Attribute type: `geo:json`.
+    + Attribute type: `geo:polygon` or `geo:json` (of type `Polygon`).
     + Normative References: [https://tools.ietf.org/html/rfc7946](https://tools.ietf.org/html/rfc7946)
     + Mandatory
   

--- a/Weather/WeatherForecast/doc/spec.md
+++ b/Weather/WeatherForecast/doc/spec.md
@@ -31,7 +31,7 @@ A JSON Schema corresponding to this data model can be found [here](http://fiware
     + Optional
 
 + `location` : Location of the weather observation represented by a GeoJSON geometry. 
-    + Attribute type: `geo:json`.
+    + Attribute type: any of the location formats supported by NGSIv2 (`geo:point`, `geo:line`, `geo:box`, `geo:polygon` or `geo:json`).
     + Normative References: [https://tools.ietf.org/html/rfc7946](https://tools.ietf.org/html/rfc7946)
     + Mandatory if `address` is not defined. 
     

--- a/Weather/WeatherObserved/doc/spec.md
+++ b/Weather/WeatherObserved/doc/spec.md
@@ -26,7 +26,7 @@ A JSON Schema corresponding to this data model can be found [here](https://fiwar
     + Optional
 
 + `location` : Location of the weather observation represented by a GeoJSON geometry. 
-    + Attribute type: `geo:json`.
+    + Attribute type: any of the location formats supported by NGSIv2 (`geo:point`, `geo:line`, `geo:box`, `geo:polygon` or `geo:json`).
     + Normative References: [https://tools.ietf.org/html/rfc7946](https://tools.ietf.org/html/rfc7946)
     + Mandatory if `address` is not defined. 
     

--- a/datamodel_template.md
+++ b/datamodel_template.md
@@ -27,7 +27,7 @@ A JSON Schema corresponding to this data model can be found {{add link to JSON S
 {{Location and address are two typical attributes that are added here for convenience}}
 
 + `location` : Location of {{entity type}} represented by a GeoJSON geometry. 
-    + Attribute type: `geo:json`.
+    + Attribute type: any of the location formats supported by NGSIv2 (`geo:point`, `geo:line`, `geo:box`, `geo:polygon` or `geo:json`).
     + Normative References: [https://tools.ietf.org/html/rfc7946](https://tools.ietf.org/html/rfc7946)
     + Mandatory if `address` is not defined. 
     


### PR DESCRIPTION
This PR improves location field in all existing models in the following way:

* It expand the usage of type to ge:point, geo:line, geo:polygon and geo:box, when applicable.
* For geo:json, it defines which expecific types are valid (Point, LineString, MultiLineString, etc.), when applicable.

CC: @jmcanterafonseca @manucarrace @mrutid