### PR TITLE
StreetlightControlCabinet attributes de-normalization

### DIFF
--- a/specs/StreetLighting/StreetlightControlCabinet/doc/spec.md
+++ b/specs/StreetLighting/StreetlightControlCabinet/doc/spec.md
@@ -244,12 +244,10 @@ The data model is defined as shown below:
             -   Type: [DateTime](http://schema.org/DateTime)
     -   Optional
 
--   `activePower` : Active power consumed per phase. The actual values will be
-    conveyed by subproperties which name will be equal to the name of each of
-    the alternating current phases, typically R, S, T.
+-   `activePowerR` : Active power consumed in R phase.
 
     -   Attribute type: Property.
-        [StructuredValue](http://schema.org/StructuredValue)
+        [Number](http://schema.org/Number)
     -   Default unit: Kilowatts (kW)
     -   Attribute metadata:
         -   `timestamp`: Timestamp when the last update of the attribute
@@ -257,12 +255,32 @@ The data model is defined as shown below:
             -   Type: [DateTime](http://schema.org/DateTime)
     -   Optional
 
--   `reactivePower` : Reactive power. The actual values will be conveyed by
-    subproperties which name will be equal to the name of each of the
-    alternating current phases, typically R, S, T.
+-   `activePowerS` : Active power consumed in S phase.
 
     -   Attribute type: Property.
-        [StructuredValue](http://schema.org/StructuredValue)
+        [Number](http://schema.org/Number)
+    -   Default unit: Kilowatts (kW)
+    -   Attribute metadata:
+        -   `timestamp`: Timestamp when the last update of the attribute
+            happened.
+            -   Type: [DateTime](http://schema.org/DateTime)
+    -   Optional
+
+-   `activePowerT` : Active power consumed in T phase.
+
+    -   Attribute type: Property.
+        [Number](http://schema.org/Number)
+    -   Default unit: Kilowatts (kW)
+    -   Attribute metadata:
+        -   `timestamp`: Timestamp when the last update of the attribute
+            happened.
+            -   Type: [DateTime](http://schema.org/DateTime)
+    -   Optional
+
+-   `reactivePowerR` : Reactive power in R phase.
+
+    -   Attribute type: Property.
+        [Number](http://schema.org/Number)
     -   Default unit: KiloVolts-Ampere-Reactive (kVArh)
     -   Attribute metadata:
         -   `timestamp`: Timestamp when the last update of the attribute
@@ -270,7 +288,49 @@ The data model is defined as shown below:
             -   Type: [DateTime](http://schema.org/DateTime)
     -   Optional
 
--   `powerFactor` : Power factor.
+-   `reactivePowerS` : Reactive power in S phase.
+
+    -   Attribute type: Property.
+        [Number](http://schema.org/Number)
+    -   Default unit: KiloVolts-Ampere-Reactive (kVArh)
+    -   Attribute metadata:
+        -   `timestamp`: Timestamp when the last update of the attribute
+            happened.
+            -   Type: [DateTime](http://schema.org/DateTime)
+    -   Optional
+
+-   `reactivePowerT` : Reactive power in T phase.
+
+    -   Attribute type: Property.
+        [Number](http://schema.org/Number)
+    -   Default unit: KiloVolts-Ampere-Reactive (kVArh)
+    -   Attribute metadata:
+        -   `timestamp`: Timestamp when the last update of the attribute
+            happened.
+            -   Type: [DateTime](http://schema.org/DateTime)
+    -   Optional
+
+-   `powerFactorR` : Power factor for phase R.
+
+    -   Attribute type: Property. [Number](http://schema.org/Number)
+    -   Allowed values: A number between -1 and 1.
+    -   Attribute metadata:
+        -   `timestamp`: Timestamp when the last update of the attribute
+            happened.
+            -   Type: [DateTime](http://schema.org/DateTime)
+    -   Optional
+
+-   `powerFactorS` : Power factor for phase S.
+
+    -   Attribute type: Property. [Number](http://schema.org/Number)
+    -   Allowed values: A number between -1 and 1.
+    -   Attribute metadata:
+        -   `timestamp`: Timestamp when the last update of the attribute
+            happened.
+            -   Type: [DateTime](http://schema.org/DateTime)
+    -   Optional
+
+-   `powerFactorT` : Power factor for phase T.
 
     -   Attribute type: Property. [Number](http://schema.org/Number)
     -   Allowed values: A number between -1 and 1.
@@ -290,14 +350,10 @@ The data model is defined as shown below:
             -   Type: [DateTime](http://schema.org/DateTime)
     -   Optional
 
--   `intensity` : Electric intensity. The actual values will be conveyed by one
-    subproperty per alternating current phase. The name of each subproperty will
-    be equal to a phase mnemonic. The mnemonic used for denoting phases can vary
-    depending on world regions. In Europe they are typically named as `R`, `S`,
-    `T`.
+-   `intensityR` : Electric intensity in R phase.
 
     -   Attribute type: Property.
-        [StructuredValue](http://schema.org/StructuredValue)
+        [Number](http://schema.org/Number)
     -   Default unit: Ampers (A)
     -   Attribute metadata:
         -   `timestamp`: Timestamp when the last update of the attribute
@@ -305,14 +361,32 @@ The data model is defined as shown below:
             -   Type: [DateTime](http://schema.org/DateTime)
     -   Optional
 
--   `voltage` : Electric tension. The actual values will be conveyed by one
-    subproperty alternating current phase. The name of each subproperty will be
-    equal to a phase mnemonic. The mnemonic used for denoting phases can vary
-    depending on world regions. In Europe they are typically named as `R`, `S`,
-    `T`.
+-   `intensityS` : Electric intensity in S phase.
 
     -   Attribute type: Property.
-        [StructuredValue](http://schema.org/StructuredValue)
+        [Number](http://schema.org/Number)
+    -   Default unit: Ampers (A)
+    -   Attribute metadata:
+        -   `timestamp`: Timestamp when the last update of the attribute
+            happened.
+            -   Type: [DateTime](http://schema.org/DateTime)
+    -   Optional
+
+-   `intensityT` : Electric intensity in T phase.
+
+    -   Attribute type: Property.
+        [Number](http://schema.org/Number)
+    -   Default unit: Ampers (A)
+    -   Attribute metadata:
+        -   `timestamp`: Timestamp when the last update of the attribute
+            happened.
+            -   Type: [DateTime](http://schema.org/DateTime)
+    -   Optional
+
+-   `voltageR` : Electric tension in phase R.
+
+    -   Attribute type: Property.
+        [Number](http://schema.org/Number)
     -   Default unit: Volts (V)
     -   Attribute metadata:
         -   `timestamp`: Timestamp when the last update of the attribute
@@ -320,23 +394,67 @@ The data model is defined as shown below:
             -   Type: [DateTime](http://schema.org/DateTime)
     -   Optional
 
--   `thdrVoltage` : Total harmonic distortion (R) of The name of each
-    subproperty will be equal to a phase mnemonic. The mnemonic used for
-    denoting phases can vary depending on world regions. In Europe they are
-    typically named as `R`, `S`, `T`.
+-   `voltageS` : Electric tension in phase S.
 
     -   Attribute type: Property.
-        [StructuredValue](http://schema.org/StructuredValue)
+        [Number](http://schema.org/Number)
+    -   Default unit: Volts (V)
+    -   Attribute metadata:
+        -   `timestamp`: Timestamp when the last update of the attribute
+            happened.
+            -   Type: [DateTime](http://schema.org/DateTime)
+    -   Optional
+
+-   `voltageT` : Electric tension in phase T.
+
+    -   Attribute type: Property.
+        [Number](http://schema.org/Number)
+    -   Default unit: Volts (V)
+    -   Attribute metadata:
+        -   `timestamp`: Timestamp when the last update of the attribute
+            happened.
+            -   Type: [DateTime](http://schema.org/DateTime)
+    -   Optional
+
+-   `thdrVoltageR` : Total harmonic distortion (R) of voltage in phase T.
+
+    -   Attribute type: Property.
+        [Number](http://schema.org/Number)
     -   Allowed values: A number between 0 and 1.
     -   Optional
 
--   `thdrIntensity` : Total harmonic distortion (R) of intensity. The name of
-    each subproperty will be equal to a phase mnemonic. The mnemonic used for
-    denoting phases can vary depending on world regions. In Europe they are
-    typically named as `R`, `S`, `T`.
+-   `thdrVoltageS` : Total harmonic distortion (R) of voltage in phase S.
 
     -   Attribute type: Property.
-        [StructuredValue](http://schema.org/StructuredValue)
+        [Number](http://schema.org/Number)
+    -   Allowed values: A number between 0 and 1.
+    -   Optional
+
+-   `thdrVoltageT` : Total harmonic distortion (R) of voltage in phase T.
+
+    -   Attribute type: Property.
+        [Number](http://schema.org/Number)
+    -   Allowed values: A number between 0 and 1.
+    -   Optional
+
+-   `thdrIntensityR` : Total harmonic distortion (R) of intensity in phase R.
+
+    -   Attribute type: Property.
+        [Number](http://schema.org/Number)
+    -   Allowed values: A number between 0 and 1.
+    -   Optional
+
+-   `thdrIntensityS` : Total harmonic distortion (R) of intensity in phase S.
+
+    -   Attribute type: Property.
+        [Number](http://schema.org/Number)
+    -   Allowed values: A number between 0 and 1.
+    -   Optional
+
+-   `thdrIntensityT` : Total harmonic distortion (R) of intensity in phase T.
+
+    -   Attribute type: Property.
+        [Number](http://schema.org/Number)
     -   Allowed values: A number between 0 and 1.
     -   Optional
 
@@ -375,12 +493,17 @@ Normalized NGSI response
     "compliantWith": {
         "value": ["IP54"]
     },
-    "intensity": {
-        "value": {
-            "S": 14.4,
-            "R": 20.1,
-            "T": 22
-        }
+    "intensityR": {
+        "type": "Number",
+        "value": 20.1
+    },
+    "intensityS": {
+        "type": "Number",
+        "value": 14.4
+    },
+    "intensityT": {
+        "type": "Number",
+        "value": 22
     },
     "workingMode": {
         "value": "automatic"
@@ -404,12 +527,17 @@ Normalized NGSI response
             "coordinates": [-3.164485591715449, 40.62785133667262]
         }
     },
-    "reactivePower": {
-        "value": {
-            "S": 43.5,
-            "R": 45,
-            "T": 42
-        }
+    "reactivePowerR": {
+        "type": "Number",
+        "value": 45
+    },
+    "reactivePowerS": {
+        "type": "Number",
+        "value": 43.5
+    },
+    "reactivePowerT": {
+        "type": "Number",
+        "value": 42
     },
     "maximumPowerAvailable": {
         "value": 10
@@ -440,16 +568,12 @@ Sample uses simplified representation for data consumers `?options=keyValues`
     "dateMeteringStarted": "2013-07-07T15:05:59.408Z",
     "lastMeterReading": 161237,
     "meterReadingPeriod": 60,
-    "intensity": {
-        "R": 20.1,
-        "S": 14.4,
-        "T": 22
-    },
-    "reactivePower": {
-        "R": 45,
-        "S": 43.5,
-        "T": 42
-    },
+    "intensityR": 20.1,
+    "intensityS": 14.4,
+    "intensityT": 22,
+    "reactivePowerR": 45,
+    "reactivePowerS": 43.5,
+    "reactivePowerT": 42,
     "workingMode": "automatic"
 }
 ```
@@ -495,13 +619,17 @@ Sample uses the NGSI-LD representation
         "type": "Property",
         "value": ["IP54"]
     },
-    "intensity": {
+    "intensityR": {
         "type": "Property",
-        "value": {
-            "S": 14.4,
-            "R": 20.1,
-            "T": 22
-        }
+        "value": 20.1
+    },
+    "intensityS": {
+        "type": "Property",
+        "value": 14.4
+    },
+    "intensityT": {
+        "type": "Property",
+        "value": 22
     },
     "workingMode": {
         "type": "Property",
@@ -530,13 +658,17 @@ Sample uses the NGSI-LD representation
             "coordinates": [-3.164485591715449, 40.62785133667262]
         }
     },
-    "reactivePower": {
+    "reactivePowerR": {
         "type": "Property",
-        "value": {
-            "S": 43.5,
-            "R": 45,
-            "T": 42
-        }
+        "value": 45
+    },
+    "reactivePowerS": {
+        "type": "Property",
+        "value": 43.5
+    },
+    "reactivePowerT": {
+        "type": "Property",
+        "value": 42
     },
     "maximumPowerAvailable": {
         "type": "Property",

--- a/specs/StreetLighting/StreetlightControlCabinet/example-normalized-ld.jsonld
+++ b/specs/StreetLighting/StreetlightControlCabinet/example-normalized-ld.jsonld
@@ -36,13 +36,17 @@
             "IP54"
         ]
     },
-    "intensity": {
+    "intensityR": {
         "type": "Property",
-        "value": {
-            "S": 14.4,
-            "R": 20.1,
-            "T": 22
-        }
+        "value": 20.1
+    },
+    "intensityS": {
+        "type": "Property",
+        "value": 14.4
+    },
+    "intensityT": {
+        "type": "Property",
+        "value": 22
     },
     "workingMode": {
         "type": "Property",
@@ -74,13 +78,17 @@
             ]
         }
     },
-    "reactivePower": {
+    "reactivePowerR": {
         "type": "Property",
-        "value": {
-            "S": 43.5,
-            "R": 45,
-            "T": 42
-        }
+        "value": 45
+    },
+    "reactivePowerS": {
+        "type": "Property",
+        "value": 43.5
+    },
+    "reactivePowerT": {
+        "type": "Property",
+        "value": 42
     },
     "maximumPowerAvailable": {
         "type": "Property",

--- a/specs/StreetLighting/StreetlightControlCabinet/example-normalized.json
+++ b/specs/StreetLighting/StreetlightControlCabinet/example-normalized.json
@@ -22,12 +22,17 @@
   "compliantWith": {
     "value": ["IP54"]
   },
-  "intensity": {
-    "value": {
-      "S": 14.4,
-      "R": 20.1,
-      "T": 22
-    }
+  "intensityR": {
+    "type": "Number",
+    "value": 20.1
+  },
+  "intensityS": {
+    "type": "Number",
+    "value": 14.4
+  },
+  "intensityT": {
+    "type": "Number",
+    "value": 22
   },
   "workingMode": {
     "value": "automatic"
@@ -51,12 +56,17 @@
       "coordinates": [-3.164485591715449, 40.62785133667262]
     }
   },
-  "reactivePower": {
-    "value": {
-      "S": 43.5,
-      "R": 45,
-      "T": 42
-    }
+  "reactivePowerR": {
+    "type": "Number",
+    "value": 45
+  },
+  "reactivePowerS": {
+    "type": "Number",
+    "value": 43.5
+  },
+  "reactivePowerT": {
+    "type": "Number",
+    "value": 42
   },
   "maximumPowerAvailable": {
     "value": 10

--- a/specs/StreetLighting/StreetlightControlCabinet/example.json
+++ b/specs/StreetLighting/StreetlightControlCabinet/example.json
@@ -16,15 +16,11 @@
   "dateMeteringStarted": "2013-07-07T15:05:59.408Z",
   "lastMeterReading": 161237,
   "meterReadingPeriod": 60,
-  "intensity": {
-    "R": 20.1,
-    "S": 14.4,
-    "T": 22
-  },
-  "reactivePower": {
-    "R": 45,
-    "S": 43.5,
-    "T": 42
-  },
+  "intensityR": 20.1,
+  "intensityS": 14.4,
+  "intensityT": 22,
+  "reactivePowerR": 45,
+  "reactivePowerS": 43.5,
+  "reactivePowerT": 42,
   "workingMode": "automatic"
 }


### PR DESCRIPTION
This PR is a contribution coming from real usage cases from Diputación de Castellón (Spain).

We propose a de-normalization of the following attributes in StreetlightControlCabinet entity type: activePower, reactivePower, intensity, thdrIntensity, thdrVoltage and voltage. Instead of having an StructureValue with an array of objects composed of name and value keys, we propose to simplify this and having attribute per each different electrical phase (R, S and T). For instance: activePowerR, activePowerS and activePowerT.

The rationale of this is that phases are always R, S and T in real-world electricity installations, so it doesn’t make sense to use sub-properties here. Indeed, using denormalized attributes such as activePowerR, activePowerS and activePowerT is easier for context consumer and context producers of this information.

In addition, we have found in real deployments that powerFactor is also specified phase by phase, so we propose to change powerFactor single attribute to powerFactorR, powerFactorS and powerFactorT attributes.

We have changed the documentation and examples in the .md files and some .json files. Changes in other places (JSON Schema? NGSI-LD schema?) are beyond our knowledge.
