### PR TITLE
Incorret Word in a sentence [ OnStreet ]

### DIFF
--- a/specs/Parking/ParkingSpot/doc/spec.md
+++ b/specs/Parking/ParkingSpot/doc/spec.md
@@ -133,7 +133,7 @@ The data model is defined as shown below:
     -   Attribute type: Property. [Text](https://schema.org/Text)
     -   Allowed values:
         -   `onstreet` : The parking spot belongs to an onstreet parking site.
-        -   `offstreet` : The parking spot belongs to an onstreet parking site.
+        -   `offstreet` : The parking spot belongs to an offstreet parking site.
         -   Other values as per application needs
     -   Mandatory
 


### PR DESCRIPTION
In "category" -> "offstreet", this attribute is writen that "The parking spot belongs to an onstreet parking site". I think there is an error in the word "onstreet". 
The correct word would be "offstreet" in that sentence?
It only this, Thanks for the great work with that documentation.